### PR TITLE
added option to reload page upon translation

### DIFF
--- a/plugin/internation/internation.esm.js
+++ b/plugin/internation/internation.esm.js
@@ -234,6 +234,10 @@ var Plugin = function Plugin() {
           switchSetter(selects, event.target.value);
           setText(event.target.value);
           sessionStorage['InternationSettingsStorage'] = event.target.value;
+          if (options.reload_on_lang_change){
+            Reveal.getCurrentSlide().remove();
+            window.location.reload(false);
+            }
         });
       });
     };
@@ -295,7 +299,8 @@ var Plugin = function Plugin() {
       html: true,
       languages: {},
       debug: false,
-      makejson: false
+      makejson: false,
+      load_on_lang_change: false,
     };
 
     var defaults = function defaults(options, defaultOptions) {

--- a/plugin/internation/internation.js
+++ b/plugin/internation/internation.js
@@ -240,6 +240,10 @@
             switchSetter(selects, event.target.value);
             setText(event.target.value);
             sessionStorage['InternationSettingsStorage'] = event.target.value;
+            if (options.reload_on_lang_change){
+              Reveal.getCurrentSlide().remove();
+              window.location.reload(false);
+              }
           });
         });
       };
@@ -301,7 +305,8 @@
         html: true,
         languages: {},
         debug: false,
-        makejson: false
+        makejson: false,
+	load_on_lang_change: false,
       };
 
       var defaults = function defaults(options, defaultOptions) {

--- a/plugin/internation/plugin-src.js
+++ b/plugin/internation/plugin-src.js
@@ -213,6 +213,10 @@ const Plugin = () => {
 					switchSetter(selects, event.target.value);
 					setText(event.target.value);
 					sessionStorage['InternationSettingsStorage'] = event.target.value;
+                                        if (options.reload_on_lang_change){
+                                          Reveal.getCurrentSlide().remove();
+                                          window.location.reload(false);
+                                          }
 				});
 
 			});
@@ -288,7 +292,8 @@ const Plugin = () => {
 			html: true,
 			languages: {},
 			debug: false,
-			makejson: false
+			makejson: false,
+                        load_on_lang_change: false,
 		};
 
 		const defaults = function(options, defaultOptions) {


### PR DESCRIPTION
added option: reload_on_lang_change; false by default.
reloads the page from cache to fix changes in the slide layout resulting from a  size change in the translated elements.

could not test plugin/internation/internation.esm.js nor .../.../plugin-src.js